### PR TITLE
Change module path to be under sendgrid-ops

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-dme/dme"
+	"github.com/sendgrid-ops/terraform-provider-dme/dme"
 )
 
 func main() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -574,5 +574,5 @@
 			"versionExact": "v1.6.1"
 		}
 	],
-	"rootPath": "github.com/terraform-providers/terraform-provider-dme"
+	"rootPath": "github.com/sendgrid-ops/terraform-provider-dme"
 }


### PR DESCRIPTION
This makes it installable with `go get -u github.com/sendgrid-ops/terraform-provider-dme` and buildable with `go build` inside the repo again.

Currently (without this PR), both of those command result in this error:

```
# github.com/sendgrid-ops/terraform-provider-dme
./main.go:10:3: cannot use dme.Provider (type func() "github.com/terraform-providers/terraform-provider-dme/vendor/github.com/hashicorp/terraform/terraform".ResourceProvider) as type "github.com/sendgrid-ops/terraform-provider-dme/vendor/github.com/hashicorp/terraform/plugin".ProviderFunc in field value
```
